### PR TITLE
service not needed for single-node cluster

### DIFF
--- a/k8s-sandbox/001-storageos-sandbox.md
+++ b/k8s-sandbox/001-storageos-sandbox.md
@@ -3,7 +3,7 @@ Verify that you have a master and a worker node (`node01`) running:
 `kubectl get nodes`{{execute}}
 
 Install CLI
-`curl -sSLo storageos https://github.com/storageos/go-cli/releases/download/0.9.2/storageos_linux_amd64 && chmod +x storageos && sudo mv storageos /usr/local/bin/; export STORAGEOS_USERNAME=storageos STORAGEOS_PASSWORD=storageos STORAGEOS_HOST=80.11.12.10`{{execute}}
+`curl -sSLo storageos https://github.com/storageos/go-cli/releases/download/0.9.2/storageos_linux_amd64 && chmod +x storageos && sudo mv storageos /usr/local/bin/; export STORAGEOS_USERNAME=storageos STORAGEOS_PASSWORD=storageos STORAGEOS_HOST=[[HOST2_IP]]`{{execute}}
 
 Create daemonset:
 
@@ -11,15 +11,6 @@ Create daemonset:
 
 You should have one pod running on `node1`:
 `kubectl get pods`{{execute}}
-
-Start service:
-
-`kubectl apply -f storageos-service.yaml`{{execute}}
-
-and verify that it is service running:
-
-`kubectl get svc storageos-api`{{execute}}
-
 
 Check that a one-node StorageOS cluster has started successfully:
 
@@ -46,4 +37,4 @@ Create Redis pod:
 
 All files:
 
-`kubectl apply -f storageos-pvc.yaml -f storageos-service.yaml -f storageos-pod.yaml -f storageos-secret.yaml -f storageos-storageclass.yaml`{{execute}}
+`kubectl apply -f storageos-pvc.yaml -f storageos-pod.yaml -f storageos-secret.yaml -f storageos-storageclass.yaml`{{execute}}


### PR DESCRIPTION
The external service address can't be contacted by the nodes themselves (not sure why), but it's not needed for the tutorial and adds complexity, so suggest we remove for now.